### PR TITLE
Remove Google SignIn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,6 @@ deploy-appbundle:
 		$(BUILD_DIR)/flacEncodeWorker.min.map \
 		$(BUILD_DIR)/device_selection_popup_bundle.min.js \
 		$(BUILD_DIR)/device_selection_popup_bundle.min.map \
-		$(BUILD_DIR)/dial_in_info_bundle.min.js \
-		$(BUILD_DIR)/dial_in_info_bundle.min.map \
 		$(BUILD_DIR)/alwaysontop.min.js \
 		$(BUILD_DIR)/alwaysontop.min.map \
 		$(OUTPUT_DIR)/analytics-ga.js \

--- a/conference.js
+++ b/conference.js
@@ -122,6 +122,7 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
 const eventEmitter = new EventEmitter();
 
 let room;
+
 let connection;
 
 /*

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -51,7 +51,6 @@ target 'JitsiMeet' do
   pod 'react-native-webrtc', :path => '../node_modules/react-native-webrtc'
   pod 'BVLinearGradient', :path => '../node_modules/react-native-linear-gradient'
   pod 'RNCAsyncStorage', :path => '../node_modules/@react-native-community/async-storage'
-  pod 'RNGoogleSignin', :path => '../node_modules/react-native-google-signin'
   pod 'RNSound', :path => '../node_modules/react-native-sound'
   pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'
   pod 'RNWatch', :path => '../node_modules/react-native-watch-connectivity'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -27,14 +27,14 @@ PODS:
     - GoogleUtilities/Network (~> 5.2)
     - "GoogleUtilities/NSData+zlib (~> 5.2)"
     - nanopb (~> 0.3)
-  - FirebaseAnalyticsInterop (1.2.0)
+  - FirebaseAnalyticsInterop (1.4.0)
   - FirebaseCore (5.3.1):
     - GoogleUtilities/Logger (~> 5.2)
   - FirebaseDynamicLinks (3.4.1):
     - FirebaseAnalytics (~> 5.1)
     - FirebaseAnalyticsInterop (~> 1.0)
     - FirebaseCore (~> 5.2)
-  - FirebaseInstanceID (3.7.0):
+  - FirebaseInstanceID (3.8.1):
     - FirebaseCore (~> 5.2)
     - GoogleUtilities/Environment (~> 5.2)
     - GoogleUtilities/UserDefaults (~> 5.2)
@@ -58,33 +58,33 @@ PODS:
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
     - "GoogleToolboxForMac/NSString+URLArguments (~> 2.1)"
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleToolboxForMac/DebugUtils (2.2.0):
-    - GoogleToolboxForMac/Defines (= 2.2.0)
-  - GoogleToolboxForMac/Defines (2.2.0)
-  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.2.0)":
-    - GoogleToolboxForMac/DebugUtils (= 2.2.0)
-    - GoogleToolboxForMac/Defines (= 2.2.0)
-    - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.0)"
-  - "GoogleToolboxForMac/NSString+URLArguments (2.2.0)"
-  - GoogleUtilities/AppDelegateSwizzler (5.4.1):
+  - GoogleToolboxForMac/DebugUtils (2.2.2):
+    - GoogleToolboxForMac/Defines (= 2.2.2)
+  - GoogleToolboxForMac/Defines (2.2.2)
+  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.2.2)":
+    - GoogleToolboxForMac/DebugUtils (= 2.2.2)
+    - GoogleToolboxForMac/Defines (= 2.2.2)
+    - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
+  - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
+  - GoogleUtilities/AppDelegateSwizzler (5.8.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (5.4.1)
-  - GoogleUtilities/Logger (5.4.1):
+  - GoogleUtilities/Environment (5.8.0)
+  - GoogleUtilities/Logger (5.8.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (5.4.1):
+  - GoogleUtilities/MethodSwizzler (5.8.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (5.4.1):
+  - GoogleUtilities/Network (5.8.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (5.4.1)"
-  - GoogleUtilities/Reachability (5.4.1):
+  - "GoogleUtilities/NSData+zlib (5.8.0)"
+  - GoogleUtilities/Reachability (5.8.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (5.4.1):
+  - GoogleUtilities/UserDefaults (5.8.0):
     - GoogleUtilities/Logger
-  - GTMSessionFetcher/Core (1.2.1)
+  - GTMSessionFetcher/Core (1.3.0)
   - nanopb (0.3.901):
     - nanopb/decode (= 0.3.901)
     - nanopb/encode (= 0.3.901)
@@ -227,7 +227,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - Amplitude-iOS
     - boost-for-react-native
     - CocoaLumberjack
@@ -323,17 +323,17 @@ SPEC CHECKSUMS:
   Fabric: f988e33c97f08930a413e08123064d2e5f68d655
   Firebase: 02f3281965c075426141a0ce1277e9de6649cab9
   FirebaseAnalytics: 23851fe602c872130a2c5c55040b302120346cc2
-  FirebaseAnalyticsInterop: efbe45c8385ec626e29f9525e5ebd38520dfb6c1
+  FirebaseAnalyticsInterop: d48b6ab67bcf016a05e55b71fc39c61c0cb6b7f3
   FirebaseCore: 52f851b30e11360f1e67cf04b1edfebf0a47a2d3
   FirebaseDynamicLinks: f209c3caccd82102caa0e91d393e3ccc593501fd
-  FirebaseInstanceID: bd6fc5a258884e206fd5c474ebe4f5b00e21770e
+  FirebaseInstanceID: a122b0c258720cf250551bb2bedf48c699f80d90
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   GoogleAppMeasurement: 6cf307834da065863f9faf4c0de0a936d81dd832
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
-  GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d
-  GoogleUtilities: 1e25823cbf46540b4284f6ef8e17b3a68ee12bbc
-  GTMSessionFetcher: 32aeca0aa144acea523e1c8e053089dec2cb98ca
+  GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
+  GoogleUtilities: 04fce34bcd5620c1ee76fb79172105c74a4df335
+  GTMSessionFetcher: 43b8b64263023d4f32caa0b40f4c8bfa3c5f36d8
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
   ObjectiveDropboxOfficial: a5afefc83f6467c42c45f2253f583f2ad1ffc701
   React: 53c53c4d99097af47cf60594b8706b4e3321e722
@@ -365,6 +365,6 @@ SPEC CHECKSUMS:
   RNWatch: 09738b339eceb66e4d80a2371633ca5fb380fa42
   yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
 
-PODFILE CHECKSUM: 2d3ae678ae96df4e73143fe7033ea2838582e7a5
+PODFILE CHECKSUM: 1ebb702d611e5711e9ec7ca3d57add62976c689a
 
-COCOAPODS: 1.7.0
+COCOAPODS: 1.8.4

--- a/ios/sdk/src/JitsiMeet.m
+++ b/ios/sdk/src/JitsiMeet.m
@@ -23,8 +23,6 @@
 #import "RCTBridgeWrapper.h"
 #import "ReactUtils.h"
 
-#import <RNGoogleSignin/RNGoogleSignin.h>
-
 
 @implementation JitsiMeet {
     RCTBridgeWrapper *_bridgeWrapper;
@@ -85,13 +83,6 @@
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
 
     if ([Dropbox application:app openURL:url options:options]) {
-        return YES;
-    }
-
-    if ([RNGoogleSignin application:app
-                            openURL:url
-                  sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
-                         annotation:options[UIApplicationOpenURLOptionsAnnotationKey]]) {
         return YES;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14134,11 +14134,6 @@
         "jssha": "^2.2.0"
       }
     },
-    "react-native-google-signin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-google-signin/-/react-native-google-signin-2.0.0.tgz",
-      "integrity": "sha512-9loM4lcCIdbco5BnmNio7yGaXQKCpCaY1VRmYiTSvC5NjuSf6Ui6jZRee46p/YdaU4yRnS3u5Vct6Psrvr0HNg=="
-    },
     "react-native-immersive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-native-immersive/-/react-native-immersive-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "react-native-background-timer": "2.1.1",
     "react-native-calendar-events": "github:jitsi/react-native-calendar-events#902e6e92d6bae450a6052f76ba4d02f977ffd8f2",
     "react-native-callstats": "3.61.0",
-    "react-native-google-signin": "2.0.0",
     "react-native-immersive": "2.0.0",
     "react-native-keep-awake": "4.0.0",
     "react-native-linear-gradient": "2.5.6",

--- a/react/features/google-api/googleApi.native.js
+++ b/react/features/google-api/googleApi.native.js
@@ -1,13 +1,5 @@
 // @flow
 
-import { NativeModules } from 'react-native';
-
-let GoogleSignin;
-
-if (NativeModules.RNGoogleSignin) {
-    GoogleSignin = require('react-native-google-signin').GoogleSignin;
-}
-
 import {
     API_URL_BROADCAST_STREAMS,
     API_URL_LIVE_BROADCASTS
@@ -22,27 +14,6 @@ import {
  * https://github.com/react-native-community/react-native-google-signin.
  */
 class GoogleApi {
-    /**
-     * Wraps the {@code GoogleSignin.configure} method.
-     *
-     * @param {Object} config - The config object to be passed to
-     * {@code GoogleSignin.configure}.
-     * @returns {void}
-     */
-    configure(config: Object) {
-        if (GoogleSignin) {
-            GoogleSignin.configure(config);
-        }
-    }
-
-    /**
-     * Retrieves the current tokens.
-     *
-     * @returns {Promise}
-     */
-    getTokens(): Promise<*> {
-        return GoogleSignin.getTokens();
-    }
 
     /**
      * Retrieves the available YouTube streams the user can use for live
@@ -65,46 +36,6 @@ class GoogleApi {
                     accessToken, broadcasts).then(resolve, reject);
             }, reject);
         });
-    }
-
-    /**
-     * Wraps the {@code GoogleSignin.hasPlayServices} method.
-     *
-     * @returns {Promise<*>}
-     */
-    hasPlayServices() {
-        if (!GoogleSignin) {
-            return Promise.reject(new Error('Google SignIn not supported'));
-        }
-
-        return GoogleSignin.hasPlayServices();
-    }
-
-    /**
-     * Wraps the {@code GoogleSignin.signIn} method.
-     *
-     * @returns {Promise<*>}
-     */
-    signIn() {
-        return GoogleSignin.signIn();
-    }
-
-    /**
-     * Wraps the {@code GoogleSignin.signInSilently} method.
-     *
-     * @returns {Promise<*>}
-     */
-    signInSilently() {
-        return GoogleSignin.signInSilently();
-    }
-
-    /**
-     * Wraps the {@code GoogleSignin.signOut} method.
-     *
-     * @returns {Promise<*>}
-     */
-    signOut() {
-        return GoogleSignin.signOut();
     }
 
     /**

--- a/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
@@ -9,12 +9,10 @@ import { connect } from '../../../../base/redux';
 
 import {
     GOOGLE_API_STATES,
-    GoogleSignInButton,
     loadGoogleAPI,
     requestAvailableYouTubeBroadcasts,
     requestLiveStreamsForYouTubeBroadcast,
     showAccountSelection,
-    signIn,
     updateProfile
 } from '../../../../google-api';
 
@@ -56,7 +54,6 @@ class StartLiveStreamDialog
         // Bind event handlers so they are only bound once per instance.
         this._onGetYouTubeBroadcasts = this._onGetYouTubeBroadcasts.bind(this);
         this._onInitializeGoogleApi = this._onInitializeGoogleApi.bind(this);
-        this._onGoogleSignIn = this._onGoogleSignIn.bind(this);
         this._onRequestGoogleSignIn = this._onRequestGoogleSignIn.bind(this);
         this._onYouTubeBroadcastIDSelected
             = this._onYouTubeBroadcastIDSelected.bind(this);
@@ -168,20 +165,6 @@ class StartLiveStreamDialog
             .catch(response => this._parseErrorFromResponse(response));
     }
 
-    _onGoogleSignIn: () => Object;
-
-    /**
-     * Forces the Google web client application to prompt for a sign in, such as
-     * when changing account, and will then fetch available YouTube broadcasts.
-     *
-     * @private
-     * @returns {Promise}
-     */
-    _onGoogleSignIn() {
-        this.props.dispatch(signIn())
-            .catch(response => this._parseErrorFromResponse(response));
-    }
-
     _onRequestGoogleSignIn: () => Object;
 
     /**
@@ -273,10 +256,6 @@ class StartLiveStreamDialog
 
         switch (this.props._googleAPIState) {
         case GOOGLE_API_STATES.LOADED:
-            googleContent
-                = <GoogleSignInButton onClick = { this._onGoogleSignIn } />;
-            helpText = t('liveStreaming.signInCTA');
-
             break;
 
         case GOOGLE_API_STATES.SIGNED_IN:
@@ -322,14 +301,6 @@ class StartLiveStreamDialog
             );
 
             break;
-        }
-
-        if (this.state.errorType !== undefined) {
-            googleContent = (
-                <GoogleSignInButton
-                    onClick = { this._onRequestGoogleSignIn } />
-            );
-            helpText = this._getGoogleErrorMessageToDisplay();
         }
 
         return (

--- a/static/dialInInfo.html
+++ b/static/dialInInfo.html
@@ -12,6 +12,5 @@
     <div id="react"></div>
     <script><!--#include virtual="/config.js" --></script>
     <script><!--#include virtual="/interface_config.js" --></script>
-    <script src="libs/dial_in_info_bundle.min.js"></script>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,10 +151,6 @@ module.exports = [
             'alwaysontop':
                 './react/features/always-on-top/index.js',
 
-            'dial_in_info_bundle': [
-                './react/features/invite/components/dial-in-info-page'
-            ],
-
             'do_external_connect':
                 './connection_optimization/do_external_connect.js',
 


### PR DESCRIPTION
The Google SigIn is being removed because this dependency uses UIWebView, a deprecated library. As consequence, it will no longer be possible to use the Google SignIn feature, and YouTube stream (which is not a problem for the current project).